### PR TITLE
Add OS requirement, and upgrade away from gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 var appdmg = require('appdmg');
 var through = require('through2');
-var gutil = require('gulp-util');
+var log = require('fancy-log');
 
-var PluginError = gutil.PluginError;
+var PluginError = require('plugin-error');
 var PLUGIN_NAME = 'gulp-appdmg';
 
 module.exports = function(options) {
@@ -13,7 +13,7 @@ module.exports = function(options) {
     var ee = appdmg(options);
 
     ee.on('progress', function(info) {
-      gutil.log(info.current + '/' + info.total + ' ' + info.type + ' ' + (info.title || info.status));
+      log(info.current + '/' + info.total + ' ' + info.type + ' ' + (info.title || info.status));
     });
 
     ee.on('error', function(err) {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/Aluxian/gulp-appdmg",
   "dependencies": {
-    "appdmg": "0.4.5",
+    "appdmg": "0.6.0",
     "fancy-log": "^1.3.3",
     "plugin-error": "^1.0.1",
     "through2": "^0.6.5"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "gulp-appdmg",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Generate beautiful DMG-images for your OS X applications.",
   "main": "index.js",
+  "os": [
+    "darwin"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/Aluxian/gulp-appdmg.git"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "homepage": "https://github.com/Aluxian/gulp-appdmg",
   "dependencies": {
     "appdmg": "0.4.5",
-    "gulp-util": "^3.0.5",
+    "fancy-log": "^1.3.3",
+    "plugin-error": "^1.0.1",
     "through2": "^0.6.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi, I'm in the middle of pondering platform dependent modules, and I notice that if I get `gulp-appdmg` to require running on darwin, instead of leaving it to `appdmg` to have an opinion I'll pull in less packages on  linux.

I've tested these changes on osx and linux. Not tested on win32, but I'd expect similar situation to linux. 